### PR TITLE
Migration to re-run statistics generation for all films.

### DIFF
--- a/imports/models/denormalizers/statistics.js
+++ b/imports/models/denormalizers/statistics.js
@@ -6,6 +6,7 @@ import { _ } from 'meteor/underscore';
 import { FilmScreeningInventory } from '../film-screening-inventory';
 import Films from '../films';
 import Screenings from '../screenings';
+import ZONES from '../zones';
 
 // Inventory functions
 function incrementOrCreate(obj, key, increment) {
@@ -21,23 +22,6 @@ function getMonthName(month) {
   ];
 
   return monthNames[month];
-}
-
-function getZoneByState(state) {
-  const zones = {
-    Sudeste: ['SP', 'ES', 'MG', 'RG'],
-    Sul: ['PR', 'SC', 'RS'],
-    'Centro-Oeste': ['DF', 'GO', 'MS', 'MT'],
-    Nordeste: ['BA', 'AL', 'CE', 'MA', 'PB', 'PE', 'PI', 'RN', 'SE'],
-    Norte: ['AM', 'PA', 'RO', 'RR', 'AC', 'AP', 'TO'],
-  };
-
-  _.each(zones, (states, zone) => {
-    if (states.indexOf(state) > 0) {
-      return zone;
-    }
-    return null;
-  });
 }
 
 const calculateStatistics = (legacyData, screenings) => {
@@ -89,8 +73,8 @@ const calculateStatistics = (legacyData, screenings) => {
       // Estados e viewers por area
       if ('uf' in screening) {
         states.push(screening.uf);
-        if (getZoneByState(screening.uf)) {
-          incrementOrCreate(statistics.viewers_zones, getZoneByState(screening.uf));
+        if (ZONES[screening.uf]) {
+          incrementOrCreate(statistics.viewers_zones, ZONES[screening.uf]);
         }
       }
 
@@ -122,7 +106,7 @@ const calculateStatistics = (legacyData, screenings) => {
 };
 
 export default {
-  _updateFilm(filmId) {
+  updateFilm(filmId) {
     // Recalculate the correct incomplete count direct from MongoDB
     const screenings = Screenings.find({
       filmId,
@@ -153,7 +137,7 @@ export default {
     Films.update(filmId, { $set: { statistics } });
   },
   afterInsertScreening(s) {
-    this._updateFilm(s.filmId);
+    this.updateFilm(s.filmId);
   },
   // afterUpdateScreening(selector, modifier) {
   // We only support very limited operations on todos

--- a/imports/models/zones.js
+++ b/imports/models/zones.js
@@ -1,0 +1,33 @@
+// An optimized hard-coded index to get zone by uf
+
+const ZONES = {
+  "SP": "Sudeste",
+  "ES": "Sudeste",
+  "MG": "Sudeste",
+  "RG": "Sudeste",
+  "PR": "Sul",
+  "SC": "Sul",
+  "RS": "Sul",
+  "DF": "Centro-Oeste",
+  "GO": "Centro-Oeste",
+  "MS": "Centro-Oeste",
+  "MT": "Centro-Oeste",
+  "BA": "Nordeste",
+  "AL": "Nordeste",
+  "CE": "Nordeste",
+  "MA": "Nordeste",
+  "PB": "Nordeste",
+  "PE": "Nordeste",
+  "PI": "Nordeste",
+  "RN": "Nordeste",
+  "SE": "Nordeste",
+  "AM": "Norte",
+  "PA": "Norte",
+  "RO": "Norte",
+  "RR": "Norte",
+  "AC": "Norte",
+  "AP": "Norte",
+  "TO": "Norte",
+};
+
+export default ZONES;

--- a/imports/startup/server/migrations.js
+++ b/imports/startup/server/migrations.js
@@ -9,6 +9,7 @@ import NotificationTemplates from '../../models/notification_templates';
 import { Cities, States } from '../../models/states_and_cities';
 import Estados from '../../../backups/Municipios-Brasileiros/json/estados.json';
 import Municipios from '../../../backups/Municipios-Brasileiros/json/municipios.json';
+import statistics from '../../models/denormalizers/statistics.js';
 
 function convertInteger(value) {
   if (value === undefined) {
@@ -202,8 +203,18 @@ Migrations.add({
   down() { },
 });
 
+Migrations.add({
+  version: 6,
+  up() {
+    Films.find({}).forEach((film) => {
+      statistics.updateFilm(film._id);
+    });
+  },
+  down() { },
+});
+
 Meteor.startup(() => {
   Migrations.migrateTo('latest');
   Migrations.unlock();
-  // Migrations.migrateTo('5,rerun');
+  // Migrations.migrateTo('6,rerun');
 });


### PR DESCRIPTION
Me parece que a issue #42 só precisa de uma migração pra rodar a rotina de gerar estatísticas pra todos os filmes.

Testei criar uma nova sessão e vi que as estatísticas mudaram.

Chequei o algoritmo também e a geração está ok. As novas estatísticas estão bem diferentes das que estavam no banco de dados.